### PR TITLE
Adding a global hotkey for bringing up the UI

### DIFF
--- a/Runway/Runway/App.xaml.cs
+++ b/Runway/Runway/App.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using System.Windows;
+using System.Windows.Input;
 using GalaSoft.MvvmLight.Ioc;
+using NHotkey;
+using NHotkey.Wpf;
 
 namespace Runway
 {
@@ -10,11 +13,15 @@ namespace Runway
          base.OnStartup( e );
 
          WireDependencies();
+
+         HotkeyManager.Current.AddOrReplace( "Launch", Key.R, ModifierKeys.Control | ModifierKeys.Shift, OnLaunch );
       }
 
       private void WireDependencies()
       {
          SimpleIoc.Default.Register<ICommandCatalog>( () => new CommandCatalog() );
       }
+
+      private void OnLaunch( object sender, HotkeyEventArgs e ) => MainWindow.Activate();
    }
 }

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -52,6 +52,14 @@
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NHotkey, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHotkey.1.2.1\lib\net20\NHotkey.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHotkey.Wpf, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHotkey.Wpf.1.2.1\lib\net35\NHotkey.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Runway/Runway/packages.config
+++ b/Runway/Runway/packages.config
@@ -3,4 +3,6 @@
   <package id="CommonServiceLocator" version="1.3" targetFramework="net462" />
   <package id="MvvmLight" version="5.3.0.0" targetFramework="net462" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net462" />
+  <package id="NHotkey" version="1.2.1" targetFramework="net462" />
+  <package id="NHotkey.Wpf" version="1.2.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
As long as the app is running, pressing this (currently-hard-coded) hotkey will bring it up. Performance is really good, since it's only "activating" and not launching the process itself. This means we'll want to keep the app in the tray or something, such that it's always running, and we're only showing the UI when asking for it.