### PR TITLE
Cleaning up how the caret is moved from the view model

### DIFF
--- a/Runway/Runway.UnitTests/Runway.UnitTests.csproj
+++ b/Runway/Runway.UnitTests/Runway.UnitTests.csproj
@@ -63,18 +63,22 @@
       <HintPath>..\packages\Moq.4.5.22\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>

--- a/Runway/Runway.UnitTests/Runway.UnitTests.csproj
+++ b/Runway/Runway.UnitTests/Runway.UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xunit.StaFact.0.1.36-beta\build\net45\Xunit.StaFact.props" Condition="Exists('..\packages\Xunit.StaFact.0.1.36-beta\build\net45\Xunit.StaFact.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -95,6 +98,10 @@
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Xunit.StaFact, Version=0.1.0.0, Culture=neutral, PublicKeyToken=593f35978b459a4b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xunit.StaFact.0.1.36-beta\lib\net45\Xunit.StaFact.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -113,6 +120,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Xunit.StaFact.0.1.36-beta\build\net45\Xunit.StaFact.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xunit.StaFact.0.1.36-beta\build\net45\Xunit.StaFact.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Runway/Runway.UnitTests/Runway.UnitTests.csproj
+++ b/Runway/Runway.UnitTests/Runway.UnitTests.csproj
@@ -106,6 +106,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\MainViewModelTests.cs" />
+    <Compile Include="Views\TextBoxExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
@@ -71,5 +71,25 @@ namespace Runway.UnitTests.ViewModels
 
          appService.Verify( @as => @as.Exit(), Times.Once() );
       }
+
+      [Fact]
+      public void CompleteSuggestionCommand_HasPreviewCommandText_RaisesMoveCaretRequested()
+      {
+         // Act
+
+         var viewModel = new MainViewModel( null, null )
+         {
+            PreviewCommandText = "Doesn't matter"
+         };
+
+         viewModel.MonitorEvents();
+
+         viewModel.CompleteSuggestionCommand.Execute( null );
+
+         // Assert
+
+         viewModel.ShouldRaise( nameof( viewModel.MoveCaretRequested ) )
+                  .WithArgs<MoveCaretEventArgs>( e => e.CaretPosition == CaretPosition.End );
+      }
    }
 }

--- a/Runway/Runway.UnitTests/Views/TextBoxExtensionsTests.cs
+++ b/Runway/Runway.UnitTests/Views/TextBoxExtensionsTests.cs
@@ -1,0 +1,6 @@
+namespace Runway.UnitTests.Views
+{
+   public class TextBoxExtensionsTests
+   {
+   }
+}

--- a/Runway/Runway.UnitTests/Views/TextBoxExtensionsTests.cs
+++ b/Runway/Runway.UnitTests/Views/TextBoxExtensionsTests.cs
@@ -1,6 +1,51 @@
+﻿using System.Windows.Controls;
+using Xunit;
+using FluentAssertions;
+using Runway.ViewModels;
+using Runway.Views;
+
 namespace Runway.UnitTests.Views
 {
    public class TextBoxExtensionsTests
    {
+      [StaFact]
+      public void MoveCaret_PassesStartPosition_SelectionStartShouldBe0()
+      {
+         // Arrange
+
+         var textBox = new TextBox
+         {
+            Text = "Some text",
+            SelectionStart = 2
+         };
+
+         // Act
+
+         textBox.MoveCaret( CaretPosition.Start );
+
+         // Assert
+
+         textBox.SelectionStart.Should().Be( 0 );
+      }
+
+      [StaFact]
+      public void MoveCaret_PassesEndPosition_SelectionStartShouldBeAtTheEnd()
+      {
+         // Arrange
+
+         var textBox = new TextBox
+         {
+            Text = "Some text",
+            SelectionStart = 2
+         };
+
+         // Act
+
+         textBox.MoveCaret( CaretPosition.End );
+
+         // Assert
+
+         textBox.SelectionStart.Should().Be( textBox.Text.Length );
+      }
    }
 }

--- a/Runway/Runway.UnitTests/packages.config
+++ b/Runway/Runway.UnitTests/packages.config
@@ -12,4 +12,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net462" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net462" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net462" />
+  <package id="Xunit.StaFact" version="0.1.36-beta" targetFramework="net462" />
 </packages>

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -84,6 +84,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Views\TextBoxExtensions.cs" />
     <Page Include="Views\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Services\IAppService.cs" />
     <Compile Include="ViewModels\CaretPosition.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
+    <Compile Include="ViewModels\MoveCaretEventArgs.cs" />
     <Compile Include="ViewModels\ViewModelLocator.cs" />
     <Compile Include="Views\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -99,6 +99,7 @@
     <Compile Include="LaunchableCommandBase.cs" />
     <Compile Include="Services\AppService.cs" />
     <Compile Include="Services\IAppService.cs" />
+    <Compile Include="ViewModels\CaretPosition.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="ViewModels\ViewModelLocator.cs" />
     <Compile Include="Views\MainWindow.xaml.cs">

--- a/Runway/Runway/ViewModels/CaretPosition.cs
+++ b/Runway/Runway/ViewModels/CaretPosition.cs
@@ -1,0 +1,8 @@
+namespace Runway.ViewModels
+{
+   public enum CaretPosition
+   {
+      Start,
+      End
+   }
+}

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -57,6 +57,8 @@ namespace Runway.ViewModels
          get;
       }
 
+      public event EventHandler<MoveCaretEventArgs> MoveCaretRequested;
+
       public MainViewModel( ICommandCatalog commandCatalog, IAppService appService )
       {
          _commandCatalog = commandCatalog;
@@ -66,6 +68,9 @@ namespace Runway.ViewModels
          LaunchCommand = new RelayCommand( OnLaunchCommand );
          ExitCommand = new RelayCommand( OnExitCommand );
       }
+
+      protected virtual void OnMoveCaretRequested( object sender, MoveCaretEventArgs e )
+         => MoveCaretRequested?.Invoke( sender, e );
 
       private void OnCompleteSuggestionCommand()
       {

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -81,7 +81,9 @@ namespace Runway.ViewModels
 
          _currentCommandText = CurrentCommandText + PreviewCommandText;
          PreviewCommandText = null;
+
          RaisePropertyChanged( () => CurrentCommandText );
+         OnMoveCaretRequested( this, new MoveCaretEventArgs( CaretPosition.End ) );
       }
 
       private void OnLaunchCommand()

--- a/Runway/Runway/ViewModels/MoveCaretEventArgs.cs
+++ b/Runway/Runway/ViewModels/MoveCaretEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Runway.ViewModels
+{
+   public class MoveCaretEventArgs : EventArgs
+   {
+      public CaretPosition CaretPosition
+      {
+         get;
+      }
+
+      public MoveCaretEventArgs( CaretPosition caretPosition )
+      {
+         CaretPosition = caretPosition;
+      }
+   }
+}

--- a/Runway/Runway/Views/MainWindow.xaml
+++ b/Runway/Runway/Views/MainWindow.xaml
@@ -14,8 +14,7 @@
    ResizeMode="NoResize"
    Background="Transparent"
    FocusManager.FocusedElement="{Binding ElementName=InputTextBox}"
-   DataContext="{Binding Main, Source={StaticResource Locator}}"
-   PreviewKeyDown="MainWindow_OnPreviewKeyDown">
+   DataContext="{Binding Main, Source={StaticResource Locator}}">
 
    <Window.Resources>
       <ResourceDictionary>
@@ -26,6 +25,7 @@
    </Window.Resources>
 
    <Window.InputBindings>
+      <KeyBinding Gesture="Tab" Command="{Binding CompleteSuggestionCommand, Mode=OneTime}" />
       <KeyBinding Gesture="Enter" Command="{Binding LaunchCommand, Mode=OneTime}" />
       <KeyBinding Gesture="Escape" Command="{Binding ExitCommand, Mode=OneTime}" />
    </Window.InputBindings>

--- a/Runway/Runway/Views/MainWindow.xaml.cs
+++ b/Runway/Runway/Views/MainWindow.xaml.cs
@@ -16,15 +16,6 @@ namespace Runway.Views
       }
 
       private void OnMoveCaretRequested( object sender, MoveCaretEventArgs e )
-      {
-         if ( e.CaretPosition == CaretPosition.Start )
-         {
-            InputTextBox.SelectionStart = 0;
-         }
-         else
-         {
-            InputTextBox.SelectionStart = InputTextBox.Text.Length;
-         }
-      }
+         => InputTextBox.MoveCaret( e.CaretPosition );
    }
 }

--- a/Runway/Runway/Views/MainWindow.xaml.cs
+++ b/Runway/Runway/Views/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using System.Windows.Input;
 using Runway.ViewModels;
 
 namespace Runway.Views
@@ -11,15 +10,19 @@ namespace Runway.Views
       public MainWindow()
       {
          InitializeComponent();
+
          _viewModel = (MainViewModel) DataContext;
+         _viewModel.MoveCaretRequested += OnMoveCaretRequested;
       }
 
-      private void MainWindow_OnPreviewKeyDown( object sender, KeyEventArgs e )
+      private void OnMoveCaretRequested( object sender, MoveCaretEventArgs e )
       {
-         if ( e.Key == Key.Tab )
+         if ( e.CaretPosition == CaretPosition.Start )
          {
-            _viewModel.CompleteSuggestionCommand.Execute( null );
-            e.Handled = true;
+            InputTextBox.SelectionStart = 0;
+         }
+         else
+         {
             InputTextBox.SelectionStart = InputTextBox.Text.Length;
          }
       }

--- a/Runway/Runway/Views/TextBoxExtensions.cs
+++ b/Runway/Runway/Views/TextBoxExtensions.cs
@@ -1,0 +1,6 @@
+namespace Runway.Views
+{
+   public static class TextBoxExtensions
+   {
+   }
+}

--- a/Runway/Runway/Views/TextBoxExtensions.cs
+++ b/Runway/Runway/Views/TextBoxExtensions.cs
@@ -1,6 +1,20 @@
+﻿using System.Windows.Controls;
+using Runway.ViewModels;
+
 namespace Runway.Views
 {
    public static class TextBoxExtensions
    {
+      public static void MoveCaret( this TextBox textBox, CaretPosition caretPosition )
+      {
+         if ( caretPosition == CaretPosition.Start )
+         {
+            textBox.SelectionStart = 0;
+         }
+         else if ( caretPosition == CaretPosition.End )
+         {
+            textBox.SelectionStart = textBox.Text.Length;
+         }
+      }
    }
 }


### PR DESCRIPTION
Uses the View Model -> event -> code-behind pattern. The actual logic is moving the caret on a real text box--this lives in an extension method (tested and run separately), keeping the code-behind tidy.