### PR TITLE
WIP Caching the currently-matched command

### DIFF
--- a/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
@@ -7,6 +7,22 @@ namespace Runway.UnitTests.ViewModels
    public class CommandParserTests
    {
       [Fact]
+      public void GetCommandSuggestion_CommandTextIsNull_ReturnsNull()
+      {
+         string suggestion = CommandParser.GetCommandSuggestion( "DoesntMatter", null );
+
+         suggestion.Should().BeNull();
+      }
+
+      [Fact]
+      public void GetCommandSuggestion_CommandTextIsEmpty_ReturnsNull()
+      {
+         string suggestion = CommandParser.GetCommandSuggestion( "DoesntMatter", string.Empty );
+
+         suggestion.Should().BeNull();
+      }
+
+      [Fact]
       public void GetCommandSuggestion_TextMatchesCommand_ReturnsNullSuggestion()
       {
          string suggestion = CommandParser.GetCommandSuggestion( "FullCommand", "FullCommand" );

--- a/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
@@ -73,6 +73,22 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
+      public void ParseArguments_CommandIsNull_ReturnsNull()
+      {
+         string arguments = CommandParser.ParseArguments( null );
+
+         arguments.Should().Be( null );
+      }
+
+      [Fact]
+      public void ParseArguments_CommandIsEmpty_ReturnsNull()
+      {
+         string arguments = CommandParser.ParseArguments( string.Empty );
+
+         arguments.Should().Be( null );
+      }
+
+      [Fact]
       public void ParseArguments_OnlyHasCommandButNoArguments_ReturnsNull()
       {
          string arguments = CommandParser.ParseArguments( "copy" );

--- a/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
@@ -27,6 +27,52 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
+      public void ParseCommand_CommandIsNull_ReturnsNull()
+      {
+         string command = CommandParser.ParseCommand( null );
+
+         command.Should().BeNull();
+      }
+
+      [Fact]
+      public void ParseCommand_CommandIsEmpty_ReturnsNull()
+      {
+         string command = CommandParser.ParseCommand( string.Empty );
+
+         command.Should().BeNull();
+      }
+
+      [Fact]
+      public void ParseCommand_HasAWholeCommandWithNoSpace_ReturnsTheCommand()
+      {
+         const string fullCommandText = "copy";
+
+         string command = CommandParser.ParseCommand( fullCommandText );
+
+         command.Should().Be( fullCommandText );
+      }
+
+      [Fact]
+      public void ParseCommand_HasWholeCommandWithTrailingSpace_ReturnsTheCommandWithSpaceRemoved()
+      {
+         const string fullCommandText = "copy";
+
+         string command = CommandParser.ParseCommand( $"{fullCommandText} " );
+
+         command.Should().Be( fullCommandText );
+      }
+
+      [Fact]
+      public void ParseCommand_HasCommandAndArguments_ReturnsCommand()
+      {
+         const string fullCommandText = "copy";
+
+         string command = CommandParser.ParseCommand( $"{fullCommandText} extra stuff after" );
+
+         command.Should().Be( fullCommandText );
+      }
+
+      [Fact]
       public void ParseArguments_OnlyHasCommandButNoArguments_ReturnsNull()
       {
          string arguments = CommandParser.ParseArguments( "copy" );

--- a/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
@@ -205,11 +205,14 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
-      public void LaunchCommand_CommandTextIsNull_DoesNotLaunchAnything()
+      public void LaunchCommand_CommandTextIsNull_LaunchesMissingCommandToDoAnything()
       {
          // Arrange
 
+         var commandMock = new Mock<ILaunchableCommand>();
+
          var commandCatalogMock = new Mock<ICommandCatalog>();
+         commandCatalogMock.Setup( cc => cc.Resolve( It.IsAny<string>() ) ).Returns( commandMock.Object );
 
          // Act
 
@@ -219,7 +222,7 @@ namespace Runway.UnitTests.ViewModels
 
          // Assert
 
-         commandCatalogMock.Verify( cc => cc.Resolve( It.IsAny<string>() ), Times.Never() );
+         commandMock.Verify( c => c.Launch( It.IsAny<object[]>() ), Times.Once() );
       }
 
       [Fact]

--- a/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
@@ -9,6 +9,14 @@ namespace Runway.UnitTests.ViewModels
    public class MainViewModelTests
    {
       [Fact]
+      public void CurrentCommand_NoCommandTextSet_CurrentCommandIsNull()
+      {
+         var viewModel = new MainViewModel( null, null );
+
+         viewModel.CurrentCommand.Should().BeNull();
+      }
+
+      [Fact]
       public void CurrentCommandText_PrefixMatchesCommand_ResolvesPreviewText()
       {
          const string partialCommand = "c";

--- a/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
@@ -63,6 +63,25 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
+      public void CompleteSuggestionCommand_HasPreviewCommandText_RaisesPropertyChangeForCurrentCommandText()
+      {
+         // Act
+
+         var viewModel = new MainViewModel( null, null )
+         {
+            PreviewCommandText = "Doesn't matter"
+         };
+
+         viewModel.MonitorEvents();
+
+         viewModel.CompleteSuggestionCommand.Execute( null );
+
+         // Assert
+
+         viewModel.ShouldRaisePropertyChangeFor( vm => vm.CurrentCommandText );
+      }
+
+      [Fact]
       public void CompleteSuggestionCommand_HasPreviewCommandText_RaisesMoveCaretRequested()
       {
          // Act

--- a/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
@@ -83,6 +83,62 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
+      public void CompleteSuggestionCommand_HasPartialTextAndSuggestion_SuggestionBecomesTheCommandText()
+      {
+         const string currentCommand = "c";
+         const string commandName = "copy";
+
+         // Arrange
+
+         var commandMock = new Mock<ILaunchableCommand>();
+         commandMock.SetupGet( c => c.CommandText ).Returns( commandName );
+
+         var commandCatalogMock = new Mock<ICommandCatalog>();
+         commandCatalogMock.Setup( cc => cc.Resolve( currentCommand ) ).Returns( commandMock.Object );
+
+         // Act
+
+         var viewModel = new MainViewModel( commandCatalogMock.Object, null )
+         {
+            CurrentCommandText = currentCommand
+         };
+
+         viewModel.CompleteSuggestionCommand.Execute( null );
+
+         // Assert
+
+         viewModel.CurrentCommandText.Should().Be( commandName );
+      }
+
+      [Fact]
+      public void CompleteSuggestionCommand_HasPartialTextAndSuggestion_PreviewTextBecomesNull()
+      {
+         const string currentCommand = "c";
+         const string commandName = "copy";
+
+         // Arrange
+
+         var commandMock = new Mock<ILaunchableCommand>();
+         commandMock.SetupGet( c => c.CommandText ).Returns( commandName );
+
+         var commandCatalogMock = new Mock<ICommandCatalog>();
+         commandCatalogMock.Setup( cc => cc.Resolve( currentCommand ) ).Returns( commandMock.Object );
+
+         // Act
+
+         var viewModel = new MainViewModel( commandCatalogMock.Object, null )
+         {
+            CurrentCommandText = currentCommand
+         };
+
+         viewModel.CompleteSuggestionCommand.Execute( null );
+
+         // Assert
+
+         viewModel.PreviewCommandText.Should().BeNull();
+      }
+
+      [Fact]
       public void CommandText_CommandNotFoundForPrefix_PreviewCommandTextIsNull()
       {
          const string command = "SomeCommand";

--- a/Runway/Runway/CommandCatalog.cs
+++ b/Runway/Runway/CommandCatalog.cs
@@ -10,7 +10,7 @@ namespace Runway
 
       private class NullCommand : ILaunchableCommand
       {
-         public string CommandText => null;
+         public string CommandText => string.Empty;
 
          public void Launch( object[] parameters )
          {

--- a/Runway/Runway/ViewModels/CommandParser.cs
+++ b/Runway/Runway/ViewModels/CommandParser.cs
@@ -6,6 +6,11 @@ namespace Runway.ViewModels
    {
       public static string GetCommandSuggestion( string partialCommandText, string commandText )
       {
+         if ( string.IsNullOrEmpty( commandText ) )
+         {
+            return null;
+         }
+
          int commonIndex = commandText.IndexOf( partialCommandText, StringComparison.InvariantCultureIgnoreCase );
 
          int postCommonIndex = commonIndex + partialCommandText.Length;

--- a/Runway/Runway/ViewModels/CommandParser.cs
+++ b/Runway/Runway/ViewModels/CommandParser.cs
@@ -32,6 +32,11 @@ namespace Runway.ViewModels
 
       public static string ParseArguments( string fullCommandText )
       {
+         if ( string.IsNullOrEmpty( fullCommandText ) )
+         {
+            return null;
+         }
+
          int firstSpace = fullCommandText.TrimStart().TrimEnd().IndexOf( ' ' );
 
          if ( firstSpace == -1 )

--- a/Runway/Runway/ViewModels/CommandParser.cs
+++ b/Runway/Runway/ViewModels/CommandParser.cs
@@ -13,6 +13,23 @@ namespace Runway.ViewModels
          return commandText.Substring( postCommonIndex );
       }
 
+      public static string ParseCommand( string fullCommandText )
+      {
+         if ( string.IsNullOrEmpty( fullCommandText ) )
+         {
+            return null;
+         }
+
+         int firstSpace = fullCommandText.IndexOf( ' ' );
+
+         if ( firstSpace == -1 )
+         {
+            return fullCommandText;
+         }
+
+         return fullCommandText.Substring( 0, firstSpace );
+      }
+
       public static string ParseArguments( string fullCommandText )
       {
          int firstSpace = fullCommandText.TrimStart().TrimEnd().IndexOf( ' ' );

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -104,14 +104,7 @@ namespace Runway.ViewModels
             return;
          }
 
-         int firstSpace = CurrentCommandText.IndexOf( ' ' );
-
-         if ( firstSpace == -1 )
-         {
-            return;
-         }
-
-         string commandText = CurrentCommandText.Substring( 0, firstSpace );
+         string commandText = CommandParser.ParseCommand( CurrentCommandText );
          string argumentString = CommandParser.ParseArguments( CurrentCommandText );
 
          var launchCommand = _commandCatalog.Resolve( commandText );

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -25,11 +25,7 @@ namespace Runway.ViewModels
             if ( changed )
             {
                var command = _commandCatalog.Resolve( value );
-
-               if ( command != CommandCatalog.MissingCommand )
-               {
-                  PreviewCommandText = CommandParser.GetCommandSuggestion( value, command.CommandText );
-               }
+               PreviewCommandText = CommandParser.GetCommandSuggestion( value, command.CommandText );
             }
          }
       }

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -47,6 +47,12 @@ namespace Runway.ViewModels
          }
       }
 
+      public ILaunchableCommand CurrentCommand
+      {
+         get;
+         private set;
+      }
+
       public ICommand CompleteSuggestionCommand
       {
          get;

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -99,11 +99,6 @@ namespace Runway.ViewModels
 
       private void OnLaunchCommand()
       {
-         if ( string.IsNullOrEmpty( CurrentCommandText ) )
-         {
-            return;
-         }
-
          string commandText = CommandParser.ParseCommand( CurrentCommandText );
          string argumentString = CommandParser.ParseArguments( CurrentCommandText );
 

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -81,11 +81,6 @@ namespace Runway.ViewModels
 
       private void OnCompleteSuggestionCommand()
       {
-         if ( string.IsNullOrEmpty( PreviewCommandText ) )
-         {
-            return;
-         }
-
          _currentCommandText = CurrentCommandText + PreviewCommandText;
          PreviewCommandText = null;
 


### PR DESCRIPTION
This saves lookups if we've matched a command but arguments still need to be typed. It also creates some space for the future as the command catalog would need to return more expressive details.