### PR TITLE
Now only executes a command if there is one

### DIFF
--- a/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/MainViewModelTests.cs
@@ -295,6 +295,27 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
+      public void LaunchCommand_CommandTextDoesNotMatchAnyCommand_DoesNotDismiss()
+      {
+         // Arrange
+
+         var commandCatalogMock = new Mock<ICommandCatalog>();
+         commandCatalogMock.Setup( cc => cc.Resolve( It.IsAny<string>() ) ).Returns( CommandCatalog.EmptySet );
+
+         // Act
+
+         var viewModel = new MainViewModel( commandCatalogMock.Object, null );
+
+         viewModel.MonitorEvents();
+
+         viewModel.LaunchCommand.Execute( null );
+
+         // Assert
+
+         viewModel.ShouldNotRaise( nameof( viewModel.DismissRequested ) );
+      }
+
+      [Fact]
       public void ExitCommand_ExitCommandIsExecuted_ApplicationExits()
       {
          // Arrange

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -99,9 +99,12 @@ namespace Runway.ViewModels
          string argumentString = CommandParser.ParseArguments( CurrentCommandText );
 
          var results = _commandCatalog.Resolve( commandText );
-         results[0].Command.Launch( new object[] { argumentString } );
 
-         OnDismissRequested( this, EventArgs.Empty );
+         if ( results.Length > 0 )
+         {
+            results[0].Command.Launch( new object[] { argumentString } );
+            OnDismissRequested( this, EventArgs.Empty );
+         }
       }
    }
 }


### PR DESCRIPTION
We can refine this further in the future, probably to select one of many commands, not the first match. This will be true when the user is allowed to select the command from many results.