### PR TITLE
Changing parse methods to return empty string instead of null

### DIFF
--- a/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
+++ b/Runway/Runway.UnitTests/ViewModels/CommandParserTests.cs
@@ -89,35 +89,35 @@ namespace Runway.UnitTests.ViewModels
       }
 
       [Fact]
-      public void ParseArguments_CommandIsNull_ReturnsNull()
+      public void ParseArguments_CommandIsNull_ReturnsEmptyString()
       {
          string arguments = CommandParser.ParseArguments( null );
 
-         arguments.Should().Be( null );
+         arguments.Should().BeEmpty();
       }
 
       [Fact]
-      public void ParseArguments_CommandIsEmpty_ReturnsNull()
+      public void ParseArguments_CommandIsEmpty_ReturnsEmptyString()
       {
          string arguments = CommandParser.ParseArguments( string.Empty );
 
-         arguments.Should().Be( null );
+         arguments.Should().BeEmpty();
       }
 
       [Fact]
-      public void ParseArguments_OnlyHasCommandButNoArguments_ReturnsNull()
+      public void ParseArguments_OnlyHasCommandButNoArguments_ReturnsEmptyString()
       {
          string arguments = CommandParser.ParseArguments( "copy" );
 
-         arguments.Should().BeNull();
+         arguments.Should().BeEmpty();
       }
 
       [Fact]
-      public void ParseArguments_OnlyHasCommandWithATrailingSpaceButNoArguments_ReturnsNull()
+      public void ParseArguments_OnlyHasCommandWithATrailingSpaceButNoArguments_ReturnsEmptyString()
       {
          string arguments = CommandParser.ParseArguments( "copy " );
 
-         arguments.Should().BeNull();
+         arguments.Should().BeEmpty();
       }
 
       [Fact]

--- a/Runway/Runway/ViewModels/CommandParser.cs
+++ b/Runway/Runway/ViewModels/CommandParser.cs
@@ -39,14 +39,14 @@ namespace Runway.ViewModels
       {
          if ( string.IsNullOrEmpty( fullCommandText ) )
          {
-            return null;
+            return string.Empty;
          }
 
          int firstSpace = fullCommandText.TrimStart().TrimEnd().IndexOf( ' ' );
 
          if ( firstSpace == -1 )
          {
-            return null;
+            return string.Empty;
          }
 
          return fullCommandText.Substring( firstSpace + 1 );


### PR DESCRIPTION
This should "no op" the code paths that try to parse from the arguments. When it was null, they'd null-reference, but an empty string should return nothing safely.