### PR TITLE
Text changes now route through a Command pattern

### DIFF
--- a/Runway/Runway.UnitTests/Extensions/Int32ExtensionsTests.cs
+++ b/Runway/Runway.UnitTests/Extensions/Int32ExtensionsTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Runway.UnitTests.Extensions
+{
+   public class Int32ExtensionsTests
+   {
+   }
+}

--- a/Runway/Runway.UnitTests/Extensions/Int32ExtensionsTests.cs
+++ b/Runway/Runway.UnitTests/Extensions/Int32ExtensionsTests.cs
@@ -1,6 +1,49 @@
-﻿namespace Runway.UnitTests.Extensions
+﻿using FluentAssertions;
+using Xunit;
+using Runway.Extensions;
+
+namespace Runway.UnitTests.Extensions
 {
    public class Int32ExtensionsTests
    {
+      [Fact]
+      public void Increment_ValueIsBelowTheMax_ValueIsIncremented()
+      {
+         int value = 1;
+
+         value = value.Increment( 10 );
+
+         value.Should().Be( 2 );
+      }
+
+      [Fact]
+      public void Increment_ValueReachesTheMax_ValueIsResetTo0()
+      {
+         int value = 1;
+
+         value = value.Increment( 2 );
+
+         value.Should().Be( 0 );
+      }
+
+      [Fact]
+      public void Decrement_ValueIsAbove0_ValueIsDecremented()
+      {
+         int value = 5;
+
+         value = value.Decrement( 10 );
+
+         value.Should().Be( 4 );
+      }
+
+      [Fact]
+      public void Decrement_ValueFallsBelow0_ValueIsReset()
+      {
+         int value = 0;
+
+         value = value.Decrement( 5 );
+
+         value.Should().Be( 5 );
+      }
    }
 }

--- a/Runway/Runway.UnitTests/Runway.UnitTests.csproj
+++ b/Runway/Runway.UnitTests/Runway.UnitTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="CommandCatalogTests.cs" />
     <Compile Include="Commands\Uninstall\AppCatalogTests.cs" />
     <Compile Include="Commands\Uninstall\UninstallStringParserTests.cs" />
+    <Compile Include="Extensions\Int32ExtensionsTests.cs" />
     <Compile Include="Helpers\ArrayHelper.cs" />
     <Compile Include="Helpers\MatchResultHelper.cs" />
     <Compile Include="Input\InputControllerTests.cs" />

--- a/Runway/Runway/Extensions/Int32Extensions.cs
+++ b/Runway/Runway/Extensions/Int32Extensions.cs
@@ -2,6 +2,7 @@
 {
    public static class Int32Extensions
    {
-
+      public static int Increment( this int value, int max ) => ++value >= max ? 0 : value;
+      public static int Decrement( this int value, int reset ) => --value < 0 ? reset : value;
    }
 }

--- a/Runway/Runway/Extensions/Int32Extensions.cs
+++ b/Runway/Runway/Extensions/Int32Extensions.cs
@@ -1,0 +1,7 @@
+﻿namespace Runway.Extensions
+{
+   public static class Int32Extensions
+   {
+
+   }
+}

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Input\InputFrame.cs" />
     <Compile Include="MatchResult.cs" />
     <Compile Include="MatchType.cs" />
+    <Compile Include="ViewModels\ChangeTextRequestedEventArgs.cs" />
     <Compile Include="ViewModels\CommandParser.cs" />
     <Compile Include="ViewModels\BulkObservableCollection.cs" />
     <Compile Include="ViewModels\TextChangedEventArgsConverter.cs" />

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Commands\Uninstall\RegistryAdapter.cs" />
     <Compile Include="Commands\Uninstall\UninstallCommand.cs" />
     <Compile Include="Commands\Uninstall\UninstallStringParser.cs" />
+    <Compile Include="Extensions\Int32Extensions.cs" />
     <Compile Include="Extensions\WindowExtensions.cs" />
     <Compile Include="IMatchResult.cs" />
     <Compile Include="Input\IInputController.cs" />

--- a/Runway/Runway/Runway.csproj
+++ b/Runway/Runway/Runway.csproj
@@ -110,6 +110,7 @@
     <Compile Include="MatchType.cs" />
     <Compile Include="ViewModels\CommandParser.cs" />
     <Compile Include="ViewModels\BulkObservableCollection.cs" />
+    <Compile Include="ViewModels\TextChangedEventArgsConverter.cs" />
     <Compile Include="Views\ListBoxExtensions.cs" />
     <Compile Include="Views\TextBoxExtensions.cs" />
     <Page Include="Styles\TextBlockStyles.xaml">

--- a/Runway/Runway/ViewModels/ChangeTextRequestedEventArgs.cs
+++ b/Runway/Runway/ViewModels/ChangeTextRequestedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Runway.ViewModels
+{
+   public class ChangeTextRequestedEventArgs : EventArgs
+   {
+      public string Text
+      {
+         get;
+      }
+
+      public ChangeTextRequestedEventArgs( string text )
+      {
+         Text = text;
+      }
+   }
+}

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -96,6 +96,7 @@ namespace Runway.ViewModels
       }
 
       public event EventHandler<MoveCaretEventArgs> MoveCaretRequested;
+      public event EventHandler<ChangeTextRequestedEventArgs> ChangeTextRequested;
       public event EventHandler DismissRequested;
 
       public MainViewModel( IAppService appService, IInputController inputController )
@@ -116,6 +117,9 @@ namespace Runway.ViewModels
 
       protected virtual void OnDismissRequested( object sender, EventArgs e )
          => DismissRequested?.Invoke( sender, e );
+
+      protected virtual void OnChangeTextRequested( object sender, ChangeTextRequestedEventArgs e )
+         => ChangeTextRequested?.Invoke( sender, e );
 
       private void OnSelectNextSuggestionCommand()
       {

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -89,6 +89,11 @@ namespace Runway.ViewModels
          get;
       }
 
+      public ICommand InputTextChangedCommand
+      {
+         get;
+      }
+
       public event EventHandler<MoveCaretEventArgs> MoveCaretRequested;
       public event EventHandler DismissRequested;
 
@@ -102,6 +107,7 @@ namespace Runway.ViewModels
          LaunchCommand = new RelayCommand( OnLaunchCommand );
          ExitCommand = new RelayCommand( appService.Exit );
          DismissCommand = new RelayCommand( OnDismissCommand );
+         InputTextChangedCommand = new RelayCommand<string>( OnInputTextChanged );
       }
 
       protected virtual void OnMoveCaretRequested( object sender, MoveCaretEventArgs e )
@@ -175,6 +181,10 @@ namespace Runway.ViewModels
       {
          InputText = null;
          OnDismissRequested( this, EventArgs.Empty );
+      }
+
+      private void OnInputTextChanged( string text )
+      {
       }
    }
 }

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ namespace Runway.ViewModels
    public class MainViewModel : ViewModelBase
    {
       private readonly IInputController _inputController;
+      private bool _isUpdatingInput;
 
       public BulkObservableCollection<IMatchResult> Suggestions
       {
@@ -107,7 +108,7 @@ namespace Runway.ViewModels
          LaunchCommand = new RelayCommand( OnLaunchCommand );
          ExitCommand = new RelayCommand( appService.Exit );
          DismissCommand = new RelayCommand( OnDismissCommand );
-         InputTextChangedCommand = new RelayCommand<string>( OnInputTextChanged );
+         InputTextChangedCommand = new RelayCommand<string>( OnInputTextChanged, OnInputTextChangedCanExecute );
       }
 
       protected virtual void OnMoveCaretRequested( object sender, MoveCaretEventArgs e )
@@ -186,5 +187,7 @@ namespace Runway.ViewModels
       private void OnInputTextChanged( string text )
       {
       }
+
+      private bool OnInputTextChangedCanExecute( string text ) => !_isUpdatingInput;
    }
 }

--- a/Runway/Runway/ViewModels/MainViewModel.cs
+++ b/Runway/Runway/ViewModels/MainViewModel.cs
@@ -9,6 +9,7 @@ namespace Runway.ViewModels
 {
    public class MainViewModel : ViewModelBase
    {
+      private readonly IAppService _appService;
       private readonly IInputController _inputController;
       private bool _isUpdatingInput;
 
@@ -101,13 +102,14 @@ namespace Runway.ViewModels
 
       public MainViewModel( IAppService appService, IInputController inputController )
       {
+         _appService = appService;
          _inputController = inputController;
 
          SelectNextSuggestionCommand = new RelayCommand( OnSelectNextSuggestionCommand );
          SelectPreviousSuggestionCommand = new RelayCommand( OnSelectPreviousSuggestionCommand );
          CompleteSuggestionCommand = new RelayCommand( OnCompleteSuggestionCommand );
          LaunchCommand = new RelayCommand( OnLaunchCommand );
-         ExitCommand = new RelayCommand( appService.Exit );
+         ExitCommand = new RelayCommand( OnExitCommand );
          DismissCommand = new RelayCommand( OnDismissCommand );
          InputTextChangedCommand = new RelayCommand<string>( OnInputTextChanged, OnInputTextChangedCanExecute );
       }
@@ -181,6 +183,8 @@ namespace Runway.ViewModels
 
          OnDismissRequested( this, EventArgs.Empty );
       }
+
+      private void OnExitCommand() => _appService.Exit();
 
       private void OnDismissCommand()
       {

--- a/Runway/Runway/ViewModels/TextChangedEventArgsConverter.cs
+++ b/Runway/Runway/ViewModels/TextChangedEventArgsConverter.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Controls;
+using GalaSoft.MvvmLight.Command;
+
+namespace Runway.ViewModels
+{
+   public class TextChangedEventArgsConverter : IEventArgsConverter
+   {
+      public object Convert( object value, object parameter )
+      {
+         var textChangedEventArgs = (TextChangedEventArgs) value;
+         return ((TextBox) textChangedEventArgs.Source).Text;
+      }
+   }
+}

--- a/Runway/Runway/Views/MainWindow.xaml
+++ b/Runway/Runway/Views/MainWindow.xaml
@@ -50,14 +50,13 @@
       </Grid.RowDefinitions>
 
       <TextBox x:Name="InputTextBox"
-         Margin="0,0,55,0"
-         Text="{Binding InputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+         Margin="0,0,55,0">
          <TextBox.Resources>
             <viewModels:TextChangedEventArgsConverter x:Key="TextChangedConverter" />
          </TextBox.Resources>
          <i:Interaction.Triggers>
             <i:EventTrigger EventName="TextChanged">
-               <command:EventToCommand Command="{Binding InputTextChangedCommand, Mode=OneTime}"
+               <command:EventToCommand Command="{Binding ChangeInputTextCommand, Mode=OneTime}"
                   PassEventArgsToCommand="True"
                   EventArgsConverter="{StaticResource TextChangedConverter}" />
             </i:EventTrigger>

--- a/Runway/Runway/Views/MainWindow.xaml
+++ b/Runway/Runway/Views/MainWindow.xaml
@@ -6,6 +6,8 @@
    xmlns:local="clr-namespace:Runway"
    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
    xmlns:behaviors="clr-namespace:Runway.Behaviors"
+   xmlns:command="http://www.galasoft.ch/mvvmlight"
+   xmlns:viewModels="clr-namespace:Runway.ViewModels"
    mc:Ignorable="d"
    Title="MainWindow"
    WindowStartupLocation="CenterScreen"
@@ -49,7 +51,18 @@
 
       <TextBox x:Name="InputTextBox"
          Margin="0,0,55,0"
-         Text="{Binding InputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+         Text="{Binding InputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+         <TextBox.Resources>
+            <viewModels:TextChangedEventArgsConverter x:Key="TextChangedConverter" />
+         </TextBox.Resources>
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="TextChanged">
+               <command:EventToCommand Command="{Binding InputTextChangedCommand, Mode=OneTime}"
+                  PassEventArgsToCommand="True"
+                  EventArgsConverter="{StaticResource TextChangedConverter}" />
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </TextBox>
       <TextBox Grid.Row="0"
          Foreground="#20FFFFFF"
          Focusable="False"
@@ -135,3 +148,4 @@
       </ListBox>
    </Grid>
 </Window>
+

--- a/Runway/Runway/Views/MainWindow.xaml.cs
+++ b/Runway/Runway/Views/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ namespace Runway.Views
          _viewModel = (MainViewModel) DataContext;
          _viewModel.MoveCaretRequested += OnMoveCaretRequested;
          _viewModel.DismissRequested += OnDismissRequested;
+         _viewModel.ChangeTextRequested += OnChangeTextRequested;
          _viewModel.Suggestions.CollectionChanged += OnSuggestionsChanged;
       }
 
@@ -41,6 +42,9 @@ namespace Runway.Views
 
       private void OnDismissRequested( object sender, EventArgs e )
          => this.FadeOut();
+
+      private void OnChangeTextRequested( object sender, ChangeTextRequestedEventArgs e )
+         => InputTextBox.Text = e.Text;
 
       private void OnSuggestionsChanged( object sender, NotifyCollectionChangedEventArgs e )
          => Height = _viewModel.Suggestions.Count == 0 ? 80 : 500;


### PR DESCRIPTION
This disconnects the text change and text setting idea. By splitting it up, the two are allowed to vary, so we can freely set the text without a load of side-effects by setting a property. This greatly reduced the INPC calls, the test setups, and loads of other things.

By decoupling the input text into two actions (set and change), this gives a lot more flexibility in how we can manage the state and what rules we're bound to.